### PR TITLE
Generate sequences starting with 0

### DIFF
--- a/lib/increment-selection.coffee
+++ b/lib/increment-selection.coffee
@@ -7,7 +7,8 @@ module.exports =
     selections = editor.getSelections()
 
     if selections.length > 1
-      start = +selections[0].getText() || 1
+      text = selections[0].getText()
+      start = if isNumeric(text) then +text else 1
 
       selections.forEach (selection, index) ->
         selection.insertText (start + index).toString()
@@ -15,9 +16,12 @@ module.exports =
       lines = selections[0].getText().split('\n')
 
       if lines.length > 1
-        start = +lines[0] || 1
+        start = if isNumeric(lines[0]) then +lines[0] else 1
 
         lines.forEach (line, index) ->
           lines[index] = start + index
 
         selections[0].insertText lines.join('\n')
+
+isNumeric = (obj) ->
+    return !Array.isArray(obj) and (obj - parseFloat(obj) + 1) >= 0;


### PR DESCRIPTION
Previously when trying to generate a sequence starting with 0, a sequence starting with 1 is generated instead, since `+startText || 1` where startText = "0" evaluates to 1. This PR uses jQuery's implementation of checking whether a variable is numeric to recognise sequences even when they start with 0.
